### PR TITLE
Feature: `website_check_and_up` to auto-start stopped containers

### DIFF
--- a/src/shared/scripts/functions/website/website_check_and_up.sh
+++ b/src/shared/scripts/functions/website/website_check_and_up.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+website_check_and_up() {
+    local site_dir site_name
+    local php_container mariadb_container
+    local started_any=false
+
+    for site_dir in "$BASE_DIR/sites/"*/; do
+        [ -d "$site_dir" ] || continue
+
+        site_name=$(basename "$site_dir")
+        php_container="${site_name}-php"
+        mariadb_container="${site_name}-mariadb"
+
+        _check_and_start_container "$php_container" "$site_name"
+        _check_and_start_container "$mariadb_container" "$site_name"
+    done
+
+    if [ "$started_any" = true ]; then
+        echo ""
+        echo "✅ All stopped containers have been started (or attempted to start)."
+    fi
+}
+
+_check_and_start_container() {
+    local container_name="$1"
+    local site_name="$2"
+    local is_running
+
+    # Do not display anything if the container does not exist
+    if ! docker ps -a --format '{{.Names}}' | grep -q "^${container_name}$"; then
+        return
+    fi
+
+    # Skip if the container is already running
+    if docker ps --format '{{.Names}}' | grep -q "^${container_name}$"; then
+        return
+    fi
+
+    echo ""
+    echo "➡️  Site: $site_name"
+    echo "   ⏳ Starting container $container_name..."
+    docker start "$container_name" >/dev/null
+    started_any=true
+
+    # Check if the container is running (timeout 30s)
+    for i in {1..30}; do
+        sleep 1
+        is_running=$(docker ps --format '{{.Names}}' | grep -c "^${container_name}$")
+        if [ "$is_running" -eq 1 ]; then
+            echo "   🚀 Container $container_name is now running."
+            return
+        fi
+    done
+
+    echo "   ❌ Container $container_name failed to start after 30s."
+    echo "   📄 Showing last 20 lines of logs for $container_name:"
+    docker logs --tail 20 "$container_name"
+}

--- a/src/shared/scripts/setup-system.sh
+++ b/src/shared/scripts/setup-system.sh
@@ -17,6 +17,7 @@ done
 source "$CONFIG_FILE"
 source "$FUNCTIONS_DIR/wp_utils.sh"
 source "$FUNCTIONS_DIR/php/php_get_version.sh"
+source "$SCRIPTS_FUNCTIONS_DIR/website/website_check_and_up.sh"
 
 # ✅ Set system timezone (if needed)
 clear
@@ -86,9 +87,9 @@ if [[ "$status" != "running" ]]; then
 fi
 '
 
-# ✅ Check and create Docker network if not available
-echo -e "${YELLOW}🌐 Checking Docker network '${DOCKER_NETWORK}'...${NC}"
+# Check network & website, etc.
 create_docker_network "$DOCKER_NETWORK"
+website_check_and_up
 
 # ✅ Fetch the latest PHP tags from Docker Hub
 php_get_version


### PR DESCRIPTION
#### ✨ New Feature: `website_check_and_up()`
Automatically checks the status of the website containers (`php` and `mariadb`) for each site. If any container is stopped, it will attempt to start the container and wait for up to 30 seconds. If the container fails to start, it will display the container's logs for troubleshooting.

#### 🔍 Feature Details:
- Loops through all websites in the `sites/` directory
- Checks for containers `{site_name}-php` and `{site_name}-mariadb`
- If a container is already running → **no log is printed**
- If a container is stopped:
  - Runs `docker start`
  - Waits up to 30 seconds for the container to start
  - If the container fails to start → **displays warning and logs**
- Output is minimized, showing only relevant logs when needed

#### ⚙️ Integration:
- You can call this function in `setup-system.sh` or `main.sh` after sourcing it:
  ```bash
  source "$SCRIPTS_FUNCTIONS_DIR/website/website_check_and_up.sh"
  website_check_and_up
  ```

#### 📦 Objective:
- Ensures that all containers for websites are in a running state after system startup.
- Useful for reboots or initial setup.