### PR TITLE
PR: v1.1.7-beta hotfix

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -64,10 +64,10 @@ jobs:
       - name: 🚀 Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
-          name: "wp-docker-dev Release"
+          name: "wp-docker nightly"
           tag_name: "nightly"
           body: "Release for development version: ${{ env.DEV_VERSION }}"
-          files: dist/wp-docker-dev.zip
+          files: dist/wp-docker.zip
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src/install.sh
+++ b/src/install.sh
@@ -23,7 +23,7 @@ version_choice=${version_choice:-1}
 if [[ "$version_choice" == "2" ]]; then
   ZIP_NAME="wp-docker-dev.zip"
   echo "🛠 Installing Nightly (Testing Only) version"
-  DOWNLOAD_URL="$REPO_URL/releases/download/dev/$ZIP_NAME"
+  DOWNLOAD_URL="$REPO_URL/releases/download/nightly/$ZIP_NAME"
   INSTALL_CHANNEL="nightly"
 else
   echo "🛠 Installing Official version"


### PR DESCRIPTION
Updated Github Workflow dev-build.yml to use the file name wp-docker.zip instead of wp-docker-dev.zip.