### PR TITLE
Refactor `run_cmd` usage to exclude internal function calls

### DIFF
--- a/src/shared/scripts/functions/utils/nginx_utils.sh
+++ b/src/shared/scripts/functions/utils/nginx_utils.sh
@@ -1,6 +1,7 @@
 # =====================================
 # 🌐 nginx_utils.sh – NGINX Proxy utility functions
 # =====================================
+
 nginx_add_mount_docker() {
     local domain="$1"
     local OVERRIDE_FILE="$NGINX_PROXY_DIR/docker-compose.override.yml"
@@ -15,7 +16,7 @@ nginx_add_mount_docker() {
 
     if [ ! -f "$OVERRIDE_FILE" ]; then
         print_msg info "$INFO_DOCKER_NGINX_CREATING_DOCKER_COMPOSE_OVERRIDE"
-        cat > "$OVERRIDE_FILE" <<EOF #get NGINX_PROXY_CONTAINER from config.sh
+        cat > "$OVERRIDE_FILE" <<EOF
 services:
   $NGINX_PROXY_CONTAINER:
     volumes:
@@ -30,7 +31,7 @@ EOF
     if ! grep -Fxq "$MOUNT_ENTRY" "$OVERRIDE_FILE"; then
         if ! echo "$MOUNT_ENTRY" | tee -a "$OVERRIDE_FILE" > /dev/null; then
             print_msg error "$ERROR_DOCKER_NGINX_MOUNT_VOLUME: $MOUNT_ENTRY"
-            run_cmd nginx_remove_mount_docker "$OVERRIDE_FILE" "$MOUNT_ENTRY" "$MOUNT_LOGS"
+            nginx_remove_mount_docker "$OVERRIDE_FILE" "$MOUNT_ENTRY" "$MOUNT_LOGS"
             return 1
         fi
         print_msg success "$SUCCESS_DOCKER_NGINX_MOUNT_VOLUME: $MOUNT_ENTRY"
@@ -42,7 +43,7 @@ EOF
     if ! grep -Fxq "$MOUNT_LOGS" "$OVERRIDE_FILE"; then
         if ! echo "$MOUNT_LOGS" | tee -a "$OVERRIDE_FILE" > /dev/null; then
             print_msg error "$ERROR_DOCKER_NGINX_MOUNT_VOLUME: $MOUNT_LOGS"
-            run_cmd nginx_remove_mount_docker "$OVERRIDE_FILE" "$MOUNT_ENTRY" "$MOUNT_LOGS"
+            nginx_remove_mount_docker "$OVERRIDE_FILE" "$MOUNT_ENTRY" "$MOUNT_LOGS"
             return 1
         fi
         print_msg success "$SUCCESS_DOCKER_NGINX_MOUNT_VOLUME: $MOUNT_LOGS"
@@ -51,27 +52,20 @@ EOF
     fi
 }
 
-# Helper function to remove entries from docker-compose.override.yml
 nginx_remove_mount_docker() {
     local override_file="$1"
     local mount_entry="$2"
     local mount_logs="$3"
 
-    # Escape slashes (/) and dots (.) by replacing them with another delimiter (e.g., #)
     local safe_mount_entry="${mount_entry//\//\\\/}"
     safe_mount_entry="${safe_mount_entry//./\\\.}"
     local safe_mount_logs="${mount_logs//\//\\\/}"
     safe_mount_logs="${safe_mount_logs//./\\\.}"
 
-    # If the override file exists
     if [ -f "$override_file" ]; then
-        # Create a temporary file to store the modified content
         temp_file=$(mktemp)
-
-        # Remove the lines containing mount_entry and mount_logs
         grep -vF "$mount_entry" "$override_file" | grep -vF "$mount_logs" > "$temp_file"
 
-        # If the content was changed, replace the original file with the modified one
         if ! diff "$override_file" "$temp_file" > /dev/null; then
             mv "$temp_file" "$override_file"
             print_msg success "$SUCCESS_DOCKER_NGINX_MOUNT_REMOVED"
@@ -85,40 +79,38 @@ nginx_remove_mount_docker() {
     fi
 }
 
-# 🔁 Restart NGINX Proxy (use when changing docker-compose, mount volume, etc.)
 nginx_restart() {
   start_loading "$INFO_DOCKER_NGINX_STARTING"
   pushd "$NGINX_PROXY_DIR" > /dev/null
 
   run_cmd "docker compose down"
-    if [[ $? -ne 0 ]]; then
-        print_msg error "$ERROR_DOCKER_NGINX_STOP $NGINX_PROXY_CONTAINER"
-        run_cmd "docker ps logs $NGINX_PROXY_CONTAINER"
-        popd > /dev/null
-        return 1
-    fi
+  if [[ $? -ne 0 ]]; then
+      print_msg error "$ERROR_DOCKER_NGINX_STOP $NGINX_PROXY_CONTAINER"
+      run_cmd "docker ps logs $NGINX_PROXY_CONTAINER"
+      popd > /dev/null
+      return 1
+  fi
+
   run_cmd "docker compose up -d --force-recreate"
-    if [[ $? -ne 0 ]]; then
-        print_msg error "$ERROR_DOCKER_NGINX_START $NGINX_PROXY_CONTAINER"
-        run_cmd "docker ps logs $NGINX_PROXY_CONTAINER"
-        popd > /dev/null
-        return 1
-    fi
+  if [[ $? -ne 0 ]]; then
+      print_msg error "$ERROR_DOCKER_NGINX_START $NGINX_PROXY_CONTAINER"
+      run_cmd "docker ps logs $NGINX_PROXY_CONTAINER"
+      popd > /dev/null
+      return 1
+  fi
+
   popd > /dev/null
   stop_loading
   print_msg success "$SUCCESS_DOCKER_NGINX_RESTART"
 }
 
-
-# 🔄 Reload NGINX (use when changing config/nginx.conf/nginx site)
 nginx_reload() {
-  #echo -e "${YELLOW}🔄 Reloading NGINX Proxy...${NC}"
   start_loading "$INFO_DOCKER_NGINX_RELOADING"
-  run_cmd docker exec "$NGINX_PROXY_CONTAINER" nginx -s reload
-    if [[ $? -ne 0 ]]; then
-        print_msg error "$ERROR_DOCKER_NGINX_RELOAD : $NGINX_PROXY_CONTAINER"
-        run_cmd "docker ps logs $NGINX_PROXY_CONTAINER"
-        return 1
-    fi
-    print_msg success "$SUCCESS_DOCKER_NGINX_RELOAD"
+  run_cmd "docker exec \"$NGINX_PROXY_CONTAINER\" nginx -s reload"
+  if [[ $? -ne 0 ]]; then
+      print_msg error "$ERROR_DOCKER_NGINX_RELOAD : $NGINX_PROXY_CONTAINER"
+      run_cmd "docker ps logs $NGINX_PROXY_CONTAINER"
+      return 1
+  fi
+  print_msg success "$SUCCESS_DOCKER_NGINX_RELOAD"
 }

--- a/src/shared/scripts/functions/website/website_management_create.sh
+++ b/src/shared/scripts/functions/website/website_management_create.sh
@@ -2,98 +2,83 @@ website_management_create_logic() {
     local domain="$1"
     local php_version="$2"
 
-    SITE_DIR="$SITES_DIR/$domain"  # Use domain for directory naming
+    SITE_DIR="$SITES_DIR/$domain"
     CONTAINER_PHP="${domain}${PHP_CONTAINER_SUFFIX}"
     CONTAINER_DB="${domain}${DB_CONTAINER_SUFFIX}"
     MARIADB_VOLUME="${domain//./}${DB_VOLUME_SUFFIX}"
     LOG_FILE="$LOGS_DIR/${domain}-setup.log"
-    
-    # Function to clean up resources in case of error
+
     cleanup() {
         print_msg cancel "$MSG_CLEANING_UP"
-        # Remove any files or directories that were created
         if [[ -d "$SITE_DIR" ]]; then
-            run_cmd "rm -rf $SITE_DIR"
+            run_cmd "rm -rf '$SITE_DIR'"
             print_msg success "$SUCCESS_DIRECTORY_REMOVE: $SITE_DIR"
         fi
         if docker ps -a --filter "name=${CONTAINER_PHP}" --format '{{.Names}}' | grep -q "${CONTAINER_PHP}"; then
-            run_cmd "docker stop $CONTAINER_PHP && docker rm $CONTAINER_PHP" true
+            run_cmd "docker stop '$CONTAINER_PHP' && docker rm '$CONTAINER_PHP'"
             print_and_debug success "$SUCCESS_CONTAINER_STOP: $CONTAINER_PHP"
         fi
         if docker ps -a --filter "name=${CONTAINER_DB}" --format '{{.Names}}' | grep -q "${CONTAINER_DB}"; then
-            #docker stop "$CONTAINER_DB" && docker rm "$CONTAINER_DB"
-            run_cmd "docker stop $CONTAINER_DB && docker rm $CONTAINER_DB" true
+            run_cmd "docker stop '$CONTAINER_DB' && docker rm '$CONTAINER_DB'"
             print_and_debug success "$SUCCESS_CONTAINER_STOP: $CONTAINER_DB"
         fi
         if docker volume ls --format '{{.Name}}' | grep -q "$MARIADB_VOLUME"; then
-            #docker volume rm "$MARIADB_VOLUME"
-            run_cmd "docker volume rm $MARIADB_VOLUME" true
+            run_cmd "docker volume rm '$MARIADB_VOLUME'"
             print_and_debug success "$SUCCESS_CONTAINER_VOLUME_REMOVE: $MARIADB_VOLUME"
         fi
         if [[ -d "$SSL_DIR" ]]; then
-            rm -rf "$SSL_DIR"
-            #echo "Removed SSL directory: $SSL_DIR"
+            run_cmd "rm -rf '$SSL_DIR'"
             print_and_debug success "$SUCCESS_DIRECTORY_REMOVE: $SSL_DIR"
         fi
     }
 
-    # Trap to catch errors and execute cleanup function
     trap '
     err_func="${FUNCNAME[1]:-MAIN}"
     err_line="${BASH_LINENO[0]}"
     print_and_debug error "$ERROR_TRAP_LOG: $err_func (line $err_line)"
     cleanup
     ' ERR SIGINT
-    
-    
-    # Check if site already exists
+
     if is_directory_exist "$SITE_DIR" false; then
-        #echo -e "${RED}${CROSSMARK} Website '$domain' already exists.${NC}"
         print_msg cancel "$MSG_WEBSITE_EXISTS: $domain"
         return 1
     fi
 
-    # 🧹 Remove existing volume if exists
     if docker volume ls --format '{{.Name}}' | grep -q "^$MARIADB_VOLUME$"; then
         print_msg warning "$MSG_DOCKER_VOLUME_FOUND: $MARIADB_VOLUME"
-        run_cmd "docker volume rm $MARIADB_VOLUME" true
+        run_cmd "docker volume rm '$MARIADB_VOLUME'"
     fi
 
-    # 🗘️ Create log and directory structure
-    mkdir -p "$SITE_DIR"/{php,mariadb/conf.d,wordpress,logs,backups}
-    touch "$SITE_DIR/logs/access.log" "$SITE_DIR/logs/error.log"
-    chmod 666 "$SITE_DIR/logs/"*.log
+    run_cmd "mkdir -p '$SITE_DIR/php' '$SITE_DIR/mariadb/conf.d' '$SITE_DIR/wordpress' '$SITE_DIR/logs' '$SITE_DIR/backups'"
+    run_cmd "touch '$SITE_DIR/logs/access.log' '$SITE_DIR/logs/error.log'"
+    run_cmd "chmod 666 '$SITE_DIR/logs/'*.log"
 
-    # Copy .template_version file if exists
     TEMPLATE_VERSION_FILE="$TEMPLATES_DIR/.template_version"
     if is_file_exist "$TEMPLATE_VERSION_FILE"; then
-       run_cmd cp "$TEMPLATE_VERSION_FILE" "$SITE_DIR/.template_version"
-        
+        copy_file "$TEMPLATE_VERSION_FILE" "$SITE_DIR/.template_version"
         print_msg copy "$SUCCESS_COPY $TEMPLATE_VERSION_FILE → $SITE_DIR/.template_version"
     else
         print_msg warning "$MSG_NOT_FOUND: $TEMPLATE_VERSION_FILE"
     fi
 
-    # 🔧 Configure NGINX
     print_msg step "$STEP_WEBSITE_SETUP_NGINX: $domain"
-    run_cmd nginx_add_mount_docker "$domain" true
+    nginx_add_mount_docker "$domain"
     export domain php_version
-    run_cmd "website_setup_nginx" true
-    # ⚙️ Create configurations
+    website_setup_nginx
+
     print_msg step "$STEP_WEBSITE_SETUP_COPY_CONFIG: $domain"
-    run_cmd copy_file "$TEMPLATES_DIR/php.ini.template" "$SITE_DIR/php/php.ini" true
-    
+    copy_file "$TEMPLATES_DIR/php.ini.template" "$SITE_DIR/php/php.ini"
+
     print_msg step "$STEP_WEBSITE_SETUP_APPLY_CONFIG: $domain"
-    run_cmd apply_mariadb_config "$SITE_DIR/mariadb/conf.d/custom.cnf" true
-    run_cmd create_optimized_php_fpm_config "$SITE_DIR/php/php-fpm.conf" true
-    
+    apply_mariadb_config "$SITE_DIR/mariadb/conf.d/custom.cnf"
+    create_optimized_php_fpm_config "$SITE_DIR/php/php-fpm.conf"
+
     print_msg step "$STEP_WEBSITE_SETUP_CREATE_ENV: $domain"
-    run_cmd website_create_env "$SITE_DIR" "$domain" "$php_version" true
+    website_create_env "$SITE_DIR" "$domain" "$php_version"
 
     print_msg step "$STEP_WEBSITE_SETUP_CREATE_SSL: $domain"
-    run_cmd generate_ssl_cert "$domain" "$SSL_DIR" true
-    
-    # 🛠️ Create docker-compose.yml
+    generate_ssl_cert "$domain" "$SSL_DIR"
+
     print_msg step "$STEP_WEBSITE_SETUP_CREATE_DOCKER_COMPOSE: $domain"
     TEMPLATE_FILE="$TEMPLATES_DIR/docker-compose.yml.template"
     TARGET_FILE="$SITE_DIR/docker-compose.yml"
@@ -106,7 +91,6 @@ website_management_create_logic() {
         exit 1
     fi
 
-    # 🚀 Start containers
     print_msg step "$MSG_START_CONTAINER: $domain"
     run_in_dir "$SITE_DIR" docker compose up -d || {
         print_msg error "$ERROR_COMMAND_FAILED: docker compose up -d"
@@ -116,7 +100,7 @@ website_management_create_logic() {
 
     debug_log "  ➤ CONTAINER_PHP: $CONTAINER_PHP"
     debug_log "  ➤ CONTAINER_DB: $CONTAINER_DB"
-    
+
     if ! is_container_running "$CONTAINER_PHP" "$CONTAINER_DB"; then
         stop_loading
         print_msg error "$ERROR_CONTAINER_NOT_READY_AFTER_30S"
@@ -124,13 +108,11 @@ website_management_create_logic() {
     fi
     stop_loading
     print_msg success "$MSG_CONTAINER_READY"
-    
-    # 🔁 Restart NGINX
+
     print_msg step "$MSG_DOCKER_NGINX_RESTART"
     nginx_restart
 
-    # 🧑‍💻 Permissions
     print_msg step "$MSG_WEBSITE_PERMISSIONS: $domain"
-    run_cmd "docker exec -u root $CONTAINER_PHP chown -R nobody:nogroup /var/www/"
+    run_cmd "docker exec -u root '$CONTAINER_PHP' chown -R nobody:nogroup /var/www/"
     debug_log "✅ website_management_create_logic completed"
 }

--- a/src/shared/scripts/functions/website/website_management_delete.sh
+++ b/src/shared/scripts/functions/website/website_management_delete.sh
@@ -5,10 +5,8 @@
 website_management_delete_logic() {
   local domain="$1"
   local backup_enabled="$2"
-  
 
   if [[ -z "$domain" ]]; then
-    #echo -e "${RED}${CROSSMARK} Missing domain parameter.${NC}"
     print_msg error "$ERROR_MISSING_PARAM: --domain"
     return 1
   fi
@@ -17,50 +15,38 @@ website_management_delete_logic() {
   ENV_FILE="$SITE_DIR/.env"
 
   if ! is_directory_exist "$SITE_DIR"; then
-    echo -e "${RED}${CROSSMARK} Website '$domain' does not exist.${NC}"
+    print_msg error "$ERROR_WEBSITE_NOT_EXIST: $domain"
     return 1
   fi
 
-  #if ! is_file_exist "$ENV_FILE"; then
-  #  echo -e "${RED}${CROSSMARK} Website .env file not found!${NC}"
-  #  return 1
-  #fi
-
-  #domain=$(fetch_env_variable "$ENV_FILE" "DOMAIN")
   MARIADB_VOLUME="${domain//./}${DB_VOLUME_SUFFIX}"
   SITE_CONF_FILE="$NGINX_PROXY_DIR/conf.d/$domain.conf"
 
-  # Debug mode
   debug_log "Deleting website '$domain'..."
   debug_log "MariaDB Volume: $MARIADB_VOLUME"
   debug_log "Site conf file: $SITE_CONF_FILE"
   debug_log "Site directory: $SITE_DIR"
   debug_log "backup_enabled: $backup_enabled"
-  
-  # backup before removing
+
   if [[ "$backup_enabled" == true ]]; then
     print_msg step "$MSG_WEBSITE_BACKUP_BEFORE_REMOVE: $domain"
 
     ARCHIVE_DIR="$ARCHIVES_DIR/old_website/${domain}-$(date +%Y%m%d-%H%M%S)"
     mkdir -p "$ARCHIVE_DIR"
 
-    # Backup Database
     print_msg step "$MSG_WEBSITE_BACKING_UP_DB: $domain"
     run_cmd "bash $CLI_DIR/database_export.sh --domain=$domain --save_location=$ARCHIVE_DIR/${domain}_db.sql" true
 
-    # Backup Source Files
     print_msg step "$MSG_WEBSITE_BACKING_UP_FILES: $SITE_DIR/wordpress"
     run_cmd "bash $CLI_DIR/backup_file.sh --domain=$domain" true
 
     print_msg success "$MSG_WEBSITE_BACKUP_FILE_CREATED: $ARCHIVE_DIR"
   fi
 
-  # 🛑 Stop containers
   print_msg step "$MSG_WEBSITE_STOPPING_CONTAINERS: $domain"
-  run_cmd docker compose -f "$SITE_DIR/docker-compose.yml" down
+  run_cmd "docker compose -f \"$SITE_DIR/docker-compose.yml\" down" true
   debug_log "Stopped containers for website '$domain'."
 
-  # 🧹 Remove override entry before deleting directory using nginx_remove_mount_docker
   OVERRIDE_FILE="$NGINX_PROXY_DIR/docker-compose.override.yml"
   MOUNT_ENTRY="      - ../../sites/$domain/wordpress:/var/www/$domain"
   MOUNT_LOGS="      - ../../sites/$domain/logs:/var/www/logs/$domain"
@@ -70,31 +56,25 @@ website_management_delete_logic() {
       nginx_remove_mount_docker "$OVERRIDE_FILE" "$MOUNT_ENTRY" "$MOUNT_LOGS"
   fi
 
-  # 🗂️ Delete website directory
   print_msg step "$MSG_WEBSITE_DELETING_DIRECTORY: $SITE_DIR"
-  run_cmd "rm -rf $SITE_DIR"
+  run_cmd "rm -rf \"$SITE_DIR\"" true
   print_msg success "$SUCCESS_DIRECTORY_REMOVE: $SITE_DIR"
 
-  # 🔐 Delete SSL certificate
   print_msg step "$MSG_WEBSITE_DELETING_SSL: $domain"
-  run_cmd "rm -rf $SSL_DIR/$domain.crt"
-  run_cmd "rm -rf $SSL_DIR/$domain.key"
+  run_cmd "rm -rf \"$SSL_DIR/$domain.crt\"" true
+  run_cmd "rm -rf \"$SSL_DIR/$domain.key\"" true
   print_msg success "$SUCCESS_SSL_CERTIFICATE_REMOVED: $domain"
 
-  # 🗃️ Delete DB volume
-  #remove_volume "$MARIADB_VOLUME"
   print_msg step "$MSG_WEBSITE_DELETING_VOLUME: $MARIADB_VOLUME"
-  run_cmd docker volume rm "$MARIADB_VOLUME"
+  run_cmd "docker volume rm \"$MARIADB_VOLUME\"" true
   print_msg success "$SUCCESS_CONTAINER_VOLUME_REMOVE: $MARIADB_VOLUME"
 
-  # 🧾 Delete NGINX configuration
   if is_file_exist "$SITE_CONF_FILE"; then
     print_msg step "$MSG_WEBSITE_DELETING_NGINX_CONF: $SITE_CONF_FILE"
     remove_file "$SITE_CONF_FILE"
     print_msg success "$SUCCESS_FILE_REMOVED: $SITE_CONF_FILE"
   fi
 
-  # 🕒 Delete cronjob if exists
   if crontab -l 2>/dev/null | grep -q "$domain"; then
     tmp_cron=$(mktemp)
     crontab -l | grep -v "$domain" > "$tmp_cron"
@@ -103,7 +83,6 @@ website_management_delete_logic() {
     print_msg success "$SUCCESS_CRON_REMOVED: $domain"
   fi
 
-  # 🔁 Restart NGINX Proxy
   nginx_restart
   print_msg success "$SUCCESS_WEBSITE_REMOVED: $domain"
 }

--- a/src/shared/scripts/functions/website/website_setup_nginx.sh
+++ b/src/shared/scripts/functions/website/website_setup_nginx.sh
@@ -14,24 +14,24 @@ website_setup_nginx() {
 
   # === Remove existing config file if exists ===
   if is_file_exist "$NGINX_CONF"; then
-      print_and_debug warning "$WARNING_REMOVE_OLD_NGINX_CONF: $NGINX_CONF"
-      run_cmd rm -f "$NGINX_CONF"
+    print_and_debug warning "$WARNING_REMOVE_OLD_NGINX_CONF: $NGINX_CONF"
+    rm -f "$NGINX_CONF"
   fi
 
   # === Check and copy template ===
   if is_file_exist "$NGINX_TEMPLATE"; then
-      if [[ ! -d "$(dirname "$NGINX_TEMPLATE")" ]]; then
-          print_and_debug error "$ERROR_NGINX_TEMPLATE_DIR_MISSING: $(dirname "$NGINX_TEMPLATE")"
-          exit 1
-      fi
-
-    run_cmd cp "$NGINX_TEMPLATE" "$NGINX_CONF" true
-    run_cmd sedi "s|\${DOMAIN}|$domain|g" "$NGINX_CONF" true
-    run_cmd sedi "s|\${PHP_CONTAINER}|$domain-php|g" "$NGINX_CONF" true
-
-      print_and_debug success "$SUCCESS_NGINX_CONF_CREATED: $NGINX_CONF"
-  else
-      print_and_debug error "$ERROR_NGINX_TEMPLATE_NOT_FOUND: $NGINX_TEMPLATE"
+    if [[ ! -d "$(dirname "$NGINX_TEMPLATE")" ]]; then
+      print_and_debug error "$ERROR_NGINX_TEMPLATE_DIR_MISSING: $(dirname "$NGINX_TEMPLATE")"
       exit 1
+    fi
+
+    cp "$NGINX_TEMPLATE" "$NGINX_CONF"
+    sedi "s|\\\${DOMAIN}|$domain|g" "$NGINX_CONF"
+    sedi "s|\\\${PHP_CONTAINER}|$domain-php|g" "$NGINX_CONF"
+
+    print_and_debug success "$SUCCESS_NGINX_CONF_CREATED: $NGINX_CONF"
+  else
+    print_and_debug error "$ERROR_NGINX_TEMPLATE_NOT_FOUND: $NGINX_TEMPLATE"
+    exit 1
   fi
 }


### PR DESCRIPTION
### ♻️ Changed

- Refactored all usages of `run_cmd` to **exclude internal Bash functions** (e.g. `wp_install`, `copy_file`, `sedi`, etc.).
- Only external shell commands (e.g. `docker`, `cp`, `curl`, `rm`) are now passed through `run_cmd` for better logging and debug tracking.
- Ensured compatibility for both `DEBUG_MODE=true` and `false` scenarios.
- Fixed potential issues when using `bash -c` with function names not available in current shell context.

---

### ✅ Benefits

- Avoids `command not found` errors in DEBUG mode with internal functions.
- Improves clarity and control over what gets logged and executed via `run_cmd`.
- Ensures safer usage of shell evaluation for external commands only.

---

### 🧠 Notes

Please review especially the logic in `website_management_create_logic`, `website_setup_nginx`, `website_setup_wordpress_logic`, and others that previously used `run_cmd` with internal functions.