### PR TITLE
PR: Merge `fix/manual-input-for-wordpress-credentials-not-work` to `dev`

### DIFF
--- a/src/shared/scripts/functions/utils/misc_utils.sh
+++ b/src/shared/scripts/functions/utils/misc_utils.sh
@@ -105,11 +105,16 @@ get_input_or_test_value_secret() {
   local input=""
 
   if is_test_mode; then
+    # Trong chế độ test, trả về fallback mà không cần prompt
     echo "$fallback"
   else
+    # Hiển thị prompt mà không cần xuống dòng
     printf "%s" "$prompt"
+    # Đọc mật khẩu mà không hiển thị ra màn hình
     read -s input
+    # Hiển thị lại dòng mới sau khi nhập
     echo
+    # Trả về giá trị nhập hoặc fallback nếu không có giá trị
     echo "${input:-$fallback}"
   fi
 }

--- a/src/shared/scripts/functions/website/website_setup_wordpress.sh
+++ b/src/shared/scripts/functions/website/website_setup_wordpress.sh
@@ -74,7 +74,7 @@ website_setup_wordpress_logic() {
       done
 
       # Lấy email người dùng nhập vào
-      admin_email=$(get_input_or_test_value "$PROMPT_WEBSITE_SETUP_WORDPRESS_EMAIL" "${admin_email:-admin@$domain}")
+      admin_email=$(get_input_or_test_value "$PROMPT_WEBSITE_SETUP_WORDPRESS_EMAIL: " "${admin_email:-admin@$domain}")
   fi
 
   # 🐳 Check if PHP container is running

--- a/src/shared/scripts/functions/website/website_setup_wordpress.sh
+++ b/src/shared/scripts/functions/website/website_setup_wordpress.sh
@@ -49,25 +49,32 @@ website_setup_wordpress_logic() {
   fi
 
   if [[ "$auto_generate" == true ]]; then
-    admin_user="admin-$(openssl rand -base64 6 | tr -dc 'a-zA-Z0-9' | head -c 8)"
-    admin_password="$(openssl rand -base64 18 | tr -dc 'a-zA-Z0-9' | head -c 16)"
-    admin_email="admin@$domain.local"
+      admin_user="admin-$(openssl rand -base64 6 | tr -dc 'a-zA-Z0-9' | head -c 8)"
+      admin_password="$(openssl rand -base64 18 | tr -dc 'a-zA-Z0-9' | head -c 16)"
+      admin_email="admin@$domain.local"
   else
-    admin_user=$(get_input_or_test_value "$PROMPT_WEBSITE_SETUP_WORDPRESS_USERNAME: " "${TEST_ADMIN_USER:-admin}")
-    while [[ -z "$admin_user" ]]; do
-      print_msg warning "$WARNING_ADMIN_USERNAME_EMPTY"
+      # Lấy username người dùng nhập vào, nếu trống sẽ dùng giá trị mặc định
       admin_user=$(get_input_or_test_value "$PROMPT_WEBSITE_SETUP_WORDPRESS_USERNAME: " "${TEST_ADMIN_USER:-admin}")
-    done
+      debug_log "Admin username entered: $admin_user"  # Thêm dòng debug ở đây
 
-    admin_password=$(get_input_or_test_value_secret "$PROMPT_WEBSITE_SETUP_WORDPRESS_PASSWORD: " "${TEST_ADMIN_PASSWORD:-testpass}")
-    confirm_password=$(get_input_or_test_value_secret "$PROMPT_WEBSITE_SETUP_WORDPRESS_PASSWORD_CONFIRM: " "${TEST_ADMIN_PASSWORD:-testpass}")
-    while [[ "$admin_password" != "$confirm_password" || -z "$admin_password" ]]; do
-      print_msg warning "$WARNING_ADMIN_PASSWORD_MISMATCH"
-      admin_password=$(get_input_or_test_value_secret "$PROMPT_WEBSITE_SETUP_WORDPRESS_PASSWORD: " "${TEST_ADMIN_PASSWORD:-testpass}")
-      confirm_password=$(get_input_or_test_value_secret "$PROMPT_WEBSITE_SETUP_WORDPRESS_PASSWORD_CONFIRM: " "${TEST_ADMIN_PASSWORD:-testpass}")
-    done
+      while [[ -z "$admin_user" ]]; do
+          print_msg warning "$WARNING_ADMIN_USERNAME_EMPTY"
+          admin_user=$(get_input_or_test_value "$PROMPT_WEBSITE_SETUP_WORDPRESS_USERNAME: " "${TEST_ADMIN_USER:-admin}")
+          debug_log "Admin username entered (again): $admin_user"  # Thêm dòng debug ở đây
+      done
 
-    admin_email=$(get_input_or_test_value "$PROMPT_WEBSITE_SETUP_WORDPRESS_EMAIL" "${admin_email:-admin@$domain}")
+      # Lấy password người dùng nhập vào
+      admin_password=$(get_input_or_test_value "$PROMPT_WEBSITE_SETUP_WORDPRESS_PASSWORD: " "${TEST_ADMIN_PASSWORD:-testpass}")
+      confirm_password=$(get_input_or_test_value "$PROMPT_WEBSITE_SETUP_WORDPRESS_PASSWORD_CONFIRM: " "${TEST_ADMIN_PASSWORD:-testpass}")
+
+      while [[ "$admin_password" != "$confirm_password" || -z "$admin_password" ]]; do
+          print_msg warning "$WARNING_ADMIN_PASSWORD_MISMATCH"
+         admin_password=$(get_input_or_test_value "$PROMPT_WEBSITE_SETUP_WORDPRESS_PASSWORD: " "${TEST_ADMIN_PASSWORD:-testpass}")
+         confirm_password=$(get_input_or_test_value "$PROMPT_WEBSITE_SETUP_WORDPRESS_PASSWORD_CONFIRM: " "${TEST_ADMIN_PASSWORD:-testpass}")
+      done
+
+      # Lấy email người dùng nhập vào
+      admin_email=$(get_input_or_test_value "$PROMPT_WEBSITE_SETUP_WORDPRESS_EMAIL" "${admin_email:-admin@$domain}")
   fi
 
   # 🐳 Check if PHP container is running


### PR DESCRIPTION
Temporarily remove `get_input_or_test_value_secret` and switch to `get_input_or_test_value` to enable custom password input in WordPress setup to get it working again.