### PR TITLE
v1.1.9-beta hotfix: Syntax error in nginx_restart function

### DIFF
--- a/src/shared/config/config.sh
+++ b/src/shared/config/config.sh
@@ -25,7 +25,7 @@ else
   DEV_MODE=false
 fi
 PROJECT_DIR=$BASE_DIR
-DEBUG_MODE="false"
+DEBUG_MODE="true"
 JSON_CONFIG_FILE="$BASE_DIR/.config.json"
 
 safe_source "$BASE_DIR/shared/core/lib/json_utils.sh"

--- a/src/shared/scripts/functions/website/website_delete.sh
+++ b/src/shared/scripts/functions/website/website_delete.sh
@@ -140,7 +140,7 @@ website_logic_delete() {
   # Remove entry in .config.json
   json_delete_site_key "$domain"
   print_msg success "$SUCCESS_CONFIG_SITE_REMOVED: $domain"
-
+  safe_source "$CORE_LIB_DIR/nginx_utils.sh"
   nginx_restart
   print_msg success "$SUCCESS_WEBSITE_REMOVED: $domain"
 }


### PR DESCRIPTION
Hotfix path:
- Fix syntax error in nginx_restart function
- Add conditional check to add docker-compose.yml for NGINX in case this file is not present but NGINX container is still running.