### PR TITLE
v1.2.0-beta/fix wrong translation for Rclone setup

### DIFF
--- a/src/shared/config/config.sh
+++ b/src/shared/config/config.sh
@@ -22,7 +22,7 @@ else
 fi
 PROJECT_DIR="$BASE_DIR"
 
-DEBUG_MODE="false"
+DEBUG_MODE="true"
 JSON_CONFIG_FILE="$BASE_DIR/.config.json"
 
 # ==== 2. Load core libs and i18n ====

--- a/src/shared/lang/en.sh
+++ b/src/shared/lang/en.sh
@@ -597,7 +597,7 @@ readonly INFO_RCLONE_CREATING_CONF="Creating new Rclone configuration file: %s"
 readonly INFO_RCLONE_SELECT_STORAGE_TYPE="Select the storage type you want to set up:"
 readonly INFO_RCLONE_DRIVE_AUTH_GUIDE="Run command: rclone authorize drive on your computer to get the OAuth token."
 
-readonly PROMPT_ENTER_STORAGE_NAME="Select storage to use: "
+readonly PROMPT_ENTER_STORAGE_NAME="Enter the name of the storage you want to set up: "
 readonly STEP_RCLONE_SETTING_UP="Setting up Storage: %s..."
 
 # =============================================

--- a/src/shared/lang/vi.sh
+++ b/src/shared/lang/vi.sh
@@ -597,7 +597,7 @@ readonly INFO_RCLONE_CREATING_CONF="Đang tạo file cấu hình Rclone mới: %
 readonly INFO_RCLONE_SELECT_STORAGE_TYPE="Chọn loại storage bạn muốn thiết lập:"
 readonly INFO_RCLONE_DRIVE_AUTH_GUIDE="Chạy lệnh: rclone authorize drive trên máy tính của bạn để lấy token OAuth."
 
-readonly PROMPT_ENTER_STORAGE_NAME="Chọn storage muốn sử dụng: "
+readonly PROMPT_ENTER_STORAGE_NAME="Nhập tên storage mà bạn muốn lưu (không ký tự đặc biệt, ví dụ: wpdocker-drive) "
 readonly STEP_RCLONE_SETTING_UP="Đang thiết lập Storage: %s..."
 
 # =============================================

--- a/src/shared/scripts/functions/rclone/setup_rclone.sh
+++ b/src/shared/scripts/functions/rclone/setup_rclone.sh
@@ -1,32 +1,21 @@
 #!/bin/bash
-
-# =====================================
-# rclone_setup: Install and configure Rclone with user-defined storage
-# Requires:
-#   - $RCLONE_CONFIG_FILE and $RCLONE_CONFIG_DIR defined
-#   - brew or curl access depending on OS
-#   - Prompts user to select and configure storage type
-# =====================================
 rclone_setup() {
-  is_directory_exist "$RCLONE_CONFIG_DIR" true 
+  is_directory_exist "$RCLONE_CONFIG_DIR" true
 
   # Check if rclone is installed
-  if ! command -v rclone &> /dev/null; then
+  if ! command -v rclone &>/dev/null; then
     print_and_debug warning "$WARNING_RCLONE_NOT_INSTALLED"
-
-    # Install based on OS
     if [[ "$(uname)" == "Darwin" ]]; then
       brew install rclone || {
         print_and_debug error "$ERROR_RCLONE_INSTALL_FAILED"
         return 1
       }
     else
-    safe_curl https://rclone.org/install.sh | sudo bash || {
+      safe_curl https://rclone.org/install.sh | sudo bash || {
         print_and_debug error "$ERROR_RCLONE_INSTALL_FAILED"
         return 1
       }
     fi
-
     print_msg success "$SUCCESS_RCLONE_INSTALLED"
   else
     print_msg success "$SUCCESS_RCLONE_ALREADY_INSTALLED"
@@ -34,7 +23,7 @@ rclone_setup() {
 
   print_msg run "$INFO_RCLONE_SETUP_START"
 
-  # Create rclone config file if not exists
+  # Create config file if missing
   if ! is_file_exist "$RCLONE_CONFIG_FILE"; then
     local create_msg
     create_msg="$(printf "$INFO_RCLONE_CREATING_CONF" "$RCLONE_CONFIG_FILE")"
@@ -45,72 +34,81 @@ rclone_setup() {
     }
   fi
 
-  # Prompt for unique storage name
+  # === Prompt storage name ===
   while true; do
-    STORAGE_NAME=$(get_input_or_test_value "📌 $PROMPT_ENTER_STORAGE_NAME" "$TEST_STORAGE_NAME")
+    STORAGE_NAME=$(get_input_or_test_value "📌 $PROMPT_ENTER_STORAGE_NAME")
     STORAGE_NAME=$(echo "$STORAGE_NAME" | tr '[:upper:]' '[:lower:]' | tr -d ' ' | tr -cd '[:alnum:]_-')
 
-    debug_log "[RCLONE] Checking if storage name exists: $STORAGE_NAME"
+    if [[ -z "$STORAGE_NAME" ]]; then
+      print_msg warning "$WARNING_STORAGE_NAME_EMPTY"
+      continue
+    fi
 
     if grep -q "^\[$STORAGE_NAME\]" "$RCLONE_CONFIG_FILE"; then
       print_msg error "$(printf "$ERROR_RCLONE_STORAGE_EXISTED" "$STORAGE_NAME")"
-    else
-      break
+      continue
     fi
-  done
 
-  # Prompt to choose storage type
-  print_msg info "$INFO_RCLONE_SELECT_STORAGE_TYPE"
-  echo -e "  ${GREEN}[1]${NC} Google Drive"
-  echo -e "  ${GREEN}[2]${NC} Dropbox"
-  echo -e "  ${GREEN}[3]${NC} S3 Storage"
-  echo -e "  ${GREEN}[4]${NC} Exit"
+    # === Prompt storage type ===
+    print_msg info "$INFO_RCLONE_SELECT_STORAGE_TYPE"
+    echo -e "  ${GREEN}[1]${NC} Google Drive"
+    echo -e "  ${GREEN}[2]${NC} Dropbox"
+    echo -e "  ${GREEN}[3]${NC} S3 Storage"
+    echo -e "  ${GREEN}[4]${NC} Exit"
 
-  choice=$(get_input_or_test_value "$PROMPT_SELECT_OPTION" "$TEST_STORAGE_CHOICE")
+    local choice
+    choice=$(get_input_or_test_value "$PROMPT_SELECT_OPTION")
 
-  case "$choice" in
+    case "$choice" in
     1) STORAGE_TYPE="drive" ;;
     2) STORAGE_TYPE="dropbox" ;;
     3) STORAGE_TYPE="s3" ;;
-    4) print_msg cancel "$MSG_EXITING"; return ;;
-    *) print_msg error "$ERROR_SELECT_OPTION_INVALID"; return ;;
-  esac
+    4)
+      print_msg cancel "$MSG_EXITING"
+      return
+      ;;
+    *)
+      print_msg error "$ERROR_SELECT_OPTION_INVALID"
+      continue
+      ;;
+    esac
 
-  debug_log "[RCLONE] Storage name: $STORAGE_NAME"
-  debug_log "[RCLONE] Storage type: $STORAGE_TYPE"
+    break
+  done
 
+  
   print_msg step "$(printf "$STEP_RCLONE_SETTING_UP" "$STORAGE_NAME")"
 
   {
     echo "[$STORAGE_NAME]"
     echo "type = $STORAGE_TYPE"
-  } >> "$RCLONE_CONFIG_FILE"
+  } >>"$RCLONE_CONFIG_FILE"
 
-  # Configure credentials by storage type
+  # Configure based on storage type
   if [[ "$STORAGE_TYPE" == "drive" ]]; then
     print_msg recommend "$INFO_RCLONE_DRIVE_AUTH_GUIDE"
-    AUTH_JSON=$(get_input_or_test_value "🔑 $PROMPT_RCLONE_DRIVE_PASTE_TOKEN" "$TEST_RCLONE_AUTH_JSON")
-    echo "token = $AUTH_JSON" >> "$RCLONE_CONFIG_FILE"
+    AUTH_JSON=$(get_input_or_test_value "🔑 $PROMPT_RCLONE_DRIVE_PASTE_TOKEN")
+    echo "token = $AUTH_JSON" >>"$RCLONE_CONFIG_FILE"
     print_msg success "$SUCCESS_RCLONE_DRIVE_SETUP"
 
   elif [[ "$STORAGE_TYPE" == "dropbox" ]]; then
-    echo "token = $(rclone authorize dropbox)" >> "$RCLONE_CONFIG_FILE"
+    echo "token = $(rclone authorize dropbox)" >>"$RCLONE_CONFIG_FILE"
 
   elif [[ "$STORAGE_TYPE" == "s3" ]]; then
-    ACCESS_KEY=$(get_input_or_test_value "$PROMPT_RCLONE_S3_ACCESS_KEY" "$TEST_RCLONE_ACCESS_KEY")
-    SECRET_KEY=$(get_input_or_test_value "$PROMPT_RCLONE_S3_SECRET_KEY" "$TEST_RCLONE_SECRET_KEY")
-    REGION=$(get_input_or_test_value "$PROMPT_RCLONE_S3_REGION" "$TEST_RCLONE_REGION")
+    ACCESS_KEY=$(get_input_or_test_value "$PROMPT_RCLONE_S3_ACCESS_KEY")
+    SECRET_KEY=$(get_input_or_test_value "$PROMPT_RCLONE_S3_SECRET_KEY")
+    REGION=$(get_input_or_test_value "$PROMPT_RCLONE_S3_REGION")
 
     {
       echo "provider = AWS"
       echo "access_key_id = $ACCESS_KEY"
       echo "secret_access_key = $SECRET_KEY"
       echo "region = $REGION"
-    } >> "$RCLONE_CONFIG_FILE"
+    } >>"$RCLONE_CONFIG_FILE"
   fi
 
   print_msg success "$(printf "$SUCCESS_RCLONE_STORAGE_ADDED" "$STORAGE_NAME")"
   print_msg info "📄 Config: $BASE_DIR/$RCLONE_CONFIG_FILE"
 }
-
-# Do not execute function by default when calling script
+  print_msg info "📄 Config: $BASE_DIR/$RCLONE_CONFIG_FILE"
+}


### PR DESCRIPTION
This pull request introduces several updates to improve the functionality, user experience, and maintainability of the Rclone setup script and its associated configuration files. Key changes include enabling debug mode, refining user prompts, restructuring the `rclone_setup` function for better clarity and error handling, and updating language files for consistency.

### User Prompt Improvements:
* Updated the English prompt for entering a storage name to make it more descriptive: "Enter the name of the storage you want to set up."
* Revised the Vietnamese prompt for entering a storage name to clarify naming conventions and restrict special characters.

### `rclone_setup` Function Refinements:
* Removed outdated comments and reorganized the `rclone_setup` function for improved readability and maintainability.
* Enhanced error handling and validation for storage name input, ensuring users cannot proceed with empty or invalid names.
* Improved the flow for selecting storage types by adding a loop for invalid choices and ensuring the process continues only after valid input.
* Removed test values from prompts to ensure real user input is required during the configuration process.

These updates collectively enhance the robustness and usability of the Rclone setup process while making the codebase easier to maintain and debug.