### PR TITLE
v1.2.0-beta: PHP Extension management, add imagick as default extension

### DIFF
--- a/src/shared/scripts/cli/php_extensions.sh
+++ b/src/shared/scripts/cli/php_extensions.sh
@@ -1,0 +1,21 @@
+# === Auto-detect BASE_DIR and load config ===
+SCRIPT_PATH="$(realpath "${BASH_SOURCE[0]:-$0}")"
+while [[ "$SCRIPT_PATH" != "/" ]]; do
+    if [[ -f "$SCRIPT_PATH/shared/config/load_config.sh" ]]; then
+        source "$SCRIPT_PATH/shared/config/load_config.sh"
+
+        load_config_file
+        break
+    fi
+    SCRIPT_PATH="$(dirname "$SCRIPT_PATH")"
+done
+safe_source "$FUNCTIONS_DIR/php_loader.sh"
+
+php_cli_install_extension() {
+    local domain extension
+    domain=$(_parse_params "--domain" "$@")
+    extension=$(_parse_params "--extension" "$@")
+
+    php_logic_install_extension "$domain" "$extension"
+
+}

--- a/src/shared/scripts/functions/php/php_install_extensions.sh
+++ b/src/shared/scripts/functions/php/php_install_extensions.sh
@@ -1,0 +1,124 @@
+readonly PHP_LIST_AVAILABLE_EXTENSIONS='{
+  "ioncube_loader": {
+    "title": "Ioncube Loader",
+    "function_name": "ioncube_loader"
+  }
+}'
+
+php_prompt_install_extension() {
+    local domain
+    if ! website_get_selected domain; then
+        return 1
+    fi
+    _is_valid_domain "$domain" || return 1
+
+    local keys selected_key
+    local choice_list=()
+
+    # Tạo danh sách hiển thị từ JSON
+    mapfile -t keys < <(jq -r 'keys[]' <<<"$PHP_LIST_AVAILABLE_EXTENSIONS")
+    if [[ ${#keys[@]} -eq 0 ]]; then
+        print_msg warning "⚠️ Không có extension nào khả dụng để cài đặt."
+        return 1
+    fi
+
+    for key in "${keys[@]}"; do
+        local title
+        title=$(jq -r --arg key "$key" '.[$key].title' <<<"$PHP_LIST_AVAILABLE_EXTENSIONS")
+        choice_list+=("$key" "$title")
+    done
+
+    # Hiển thị danh sách cho người dùng chọn
+    selected_key=$(dialog --stdout --menu "📦 Chọn extension PHP để cài đặt" 15 60 6 "${choice_list[@]}")
+    if [[ -z "$selected_key" ]]; then
+        print_msg warning "⛔ Bạn đã huỷ thao tác cài đặt extension."
+        return 1
+    fi
+
+    # Gọi hàm logic đã có
+    php_logic_install_extension "$domain" "$selected_key"
+}
+
+php_logic_install_extension() {
+    local domain="$1"
+    local extension="$2"
+    _is_missing_param "$domain" "domain" || return 1
+    _is_missing_param "$extension" "extension" || return 1
+
+    local install_fn="php_install_extension_${extension//-/_}"
+    if ! declare -F "$install_fn" >/dev/null; then
+        print_and_debug error "❌ Extension '$extension' is not supported."
+        return 1
+    fi
+
+    "$install_fn" "$domain"
+}
+
+php_install_extension_ioncube_loader() {
+    local domain="$1"
+    local php_container php_version loader_file loader_path site_php_ini zts_suffix arch
+    php_container=$(json_get_site_value "$domain" "CONTAINER_PHP")
+    php_version=$(docker exec -i "$php_container" php -r 'echo PHP_VERSION;' | cut -d. -f1,2)
+    site_php_ini="$SITES_DIR/$domain/php/php.ini"
+
+    # ✅ Kiểm tra kiến trúc hệ thống
+    arch=$(docker exec -i "$php_container" uname -m | tr -d '\r')
+
+    if [[ "$arch" != "x86_64" ]]; then
+        print_msg warning "⚠️ Không thể cài đặt Ioncube Loader: kiến trúc CPU của container là '$arch' (chỉ hỗ trợ x86_64)"
+        return 0
+    fi
+
+    # ✅ Kiểm tra ZTS (Thread Safety)
+    if docker exec -i "$php_container" php -i | grep -q 'Thread Safety => enabled'; then
+        zts_suffix="_ts"
+        print_msg info "ℹ️ PHP container sử dụng Thread Safety (ZTS)"
+    else
+        zts_suffix=""
+        print_msg info "ℹ️ PHP container KHÔNG sử dụng Thread Safety (NTS)"
+    fi
+
+    loader_file="ioncube_loader_lin_${php_version}${zts_suffix}.so"
+    loader_path="/opt/bitnami/php/lib/php/extensions/${loader_file}"
+
+    print_msg step "📦 Đang kiểm tra khả năng cài đặt Ioncube Loader ($loader_file)..."
+
+    docker exec -u root -i "$php_container" bash -c "
+    mkdir -p /tmp/ioncube &&
+    curl -sSL -o /tmp/ioncube.tar.gz https://downloads.ioncube.com/loader_downloads/ioncube_loaders_lin_x86-64.tar.gz &&
+    tar -xzf /tmp/ioncube.tar.gz -C /tmp/ioncube &&
+    tar -tzf /tmp/ioncube.tar.gz > /tmp/ioncube/filelist.txt
+  "
+
+    if ! docker exec -i "$php_container" grep -q "ioncube/${loader_file}" /tmp/ioncube/filelist.txt; then
+        print_msg warning "⚠️ Không tìm thấy file Ioncube Loader phù hợp: $loader_file (PHP $php_version, ZTS=${zts_suffix:+có})"
+        docker exec -u root -i "$php_container" rm -rf /tmp/ioncube /tmp/ioncube.tar.gz
+        return 0
+    fi
+
+    docker exec -u root -i "$php_container" bash -c "
+    cp /tmp/ioncube/ioncube/${loader_file} $loader_path &&
+    chmod 755 $loader_path &&
+    rm -rf /tmp/ioncube /tmp/ioncube.tar.gz
+  "
+
+    if ! docker exec -i "$php_container" test -f "$loader_path"; then
+        print_msg warning "⚠️ Không tìm thấy file loader thực tế sau khi cài đặt: $loader_path"
+        return 1
+    fi
+
+    if [[ ! -f "$site_php_ini" ]]; then
+        print_and_debug error "❌ Không tìm thấy file PHP cấu hình: $site_php_ini"
+        return 1
+    fi
+
+    if ! grep -q "$loader_file" "$site_php_ini"; then
+        echo "zend_extension=$loader_path" >>"$site_php_ini"
+        print_msg success "✅ Đã thêm cấu hình Ioncube vào php.ini"
+    else
+        print_msg info "ℹ️ Cấu hình Ioncube đã tồn tại trong php.ini"
+    fi
+
+    docker restart "$php_container" >/dev/null
+    print_msg success "✅ Đã restart container PHP: $php_container"
+}

--- a/src/shared/scripts/menu/php_menu.sh
+++ b/src/shared/scripts/menu/php_menu.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 #shellcheck disable=SC1091
-safe_source "$FUNCTIONS_DIR/php/php_edit_conf.sh"
-safe_source "$FUNCTIONS_DIR/php/php_edit_phpini.sh"
+safe_source "$FUNCTIONS_DIR/php_loader.sh"
 safe_source "$CLI_DIR/php_version.sh"
-safe_source "$FUNCTIONS_DIR/php/php_rebuild_container.sh"
 
 # 📋 Main PHP Management Menu
 php_menu() {
@@ -13,7 +11,8 @@ php_menu() {
     print_msg label "${GREEN}2)${NC} $LABEL_MENU_PHP_REBUILD"
     print_msg label "${GREEN}3)${NC} $LABEL_MENU_PHP_EDIT_CONF"
     print_msg label "${GREEN}4)${NC} $LABEL_MENU_PHP_EDIT_INI"
-    print_msg label "${GREEN}5)${NC} $MSG_BACK"
+    print_msg label "${GREEN}5)${NC} Install PHP Extensions"
+    print_msg label "${GREEN}6)${NC} $MSG_BACK"
     echo ""
 
     read -p "$MSG_SELECT_OPTION " choice
@@ -23,7 +22,8 @@ php_menu() {
         2) php_prompt_rebuild_container; read -p "$MSG_PRESS_ENTER_CONTINUE" ;;
         3) edit_php_fpm_conf; read -p "$MSG_PRESS_ENTER_CONTINUE" ;;
         4) edit_php_ini; read -p "$MSG_PRESS_ENTER_CONTINUE" ;;
-        5) break ;;
+        5) php_prompt_install_extension; read -p "$MSG_PRESS_ENTER_CONTINUE" ;;
+        6) break ;;
         *) print_msg error "$ERROR_SELECT_OPTION_INVALID" ;;
     esac
   done

--- a/src/shared/templates/php.ini.template
+++ b/src/shared/templates/php.ini.template
@@ -18,3 +18,6 @@ opcache.memory_consumption=256
 opcache.max_accelerated_files=10000
 opcache.validate_timestamps=1
 opcache.revalidate_freq=60
+
+; Enable extensions for Bitnami images
+extension=imagick.so


### PR DESCRIPTION
This pull request introduces a new feature for managing PHP extensions, including the ability to install the Ioncube Loader extension. It also updates the PHP management menu to include an option for installing extensions and modifies the PHP configuration template to enable the `imagick` extension by default.

### New feature: PHP extension management
* Added a script (`src/shared/scripts/functions/php/php_install_extensions.sh`) to handle PHP extension installation, including logic for detecting supported extensions and installing the Ioncube Loader. The script checks system architecture, thread safety, and updates the PHP configuration (`php.ini`) as needed.
* Introduced a CLI function (`php_cli_install_extension`) in `src/shared/scripts/cli/php_extensions.sh` to allow extensions to be installed via command-line parameters.

### PHP management menu updates
* Updated the PHP management menu (`src/shared/scripts/menu/php_menu.sh`) to include a new option for installing PHP extensions. The menu now prompts the user to select an extension to install. [[1]](diffhunk://#diff-e74b29d0051a22fbaabd92378abd72be6f1ed97e475babb6ebe91afbc62bbd68L16-R15) [[2]](diffhunk://#diff-e74b29d0051a22fbaabd92378abd72be6f1ed97e475babb6ebe91afbc62bbd68L26-R26)

### PHP configuration updates
* Modified the PHP configuration template (`src/shared/templates/php.ini.template`) to enable the `imagick` extension by default for Bitnami images.